### PR TITLE
Fix indoor path to show direction

### DIFF
--- a/mobile/src/utils/svgUtils.ts
+++ b/mobile/src/utils/svgUtils.ts
@@ -90,13 +90,27 @@ export function generatePathElements(
     endX: number,
     endY: number
 ): string {
+    const arrowDef = `
+    <defs>
+      <marker 
+        id="arrowhead" 
+        markerWidth="6" 
+        markerHeight="6" 
+        refX="5" 
+        refY="3" 
+        orient="auto"
+      >
+        <polygon points="0 0, 6 3, 0 6" fill="#007AFF" />
+      </marker>
+    </defs>`;
+
     // The path string already has transformed coordinates from generateSvgPath
-    const pathElement = `<path d="${pathString}" stroke="#007AFF" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>`;
+    const pathElement = `<path d="${pathString}" stroke="#007AFF" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.9" marker-end="url(#arrowhead)"/>`;
     
     // Start and end markers
     const markers =
         `<circle cx="${startX}" cy="${startY}" r="12" fill="#34C759" stroke="#fff" stroke-width="3"/>` +
         `<circle cx="${endX}" cy="${endY}" r="12" fill="#FF3B30" stroke="#fff" stroke-width="3"/>`;
 
-    return pathElement + markers;
+    return arrowDef + pathElement + markers;
 }


### PR DESCRIPTION
## What does this PR do?
Added an arrow indicator at the end of the indoor path to show the direction the user should walk.

<img width="450" height="1024" alt="Screenshot 2026-04-02 210551" src="https://github.com/user-attachments/assets/afd54483-da92-40a7-b277-581f8ede7cec" />
<img width="467" height="1032" alt="image" src="https://github.com/user-attachments/assets/707c242a-6944-4cd3-b9cb-53948a249d02" />

## How to test
- [ ] Unit tests: npm test
- [ ] Test Coverage: npm test (or npm run test:coverage)

## Linked issue
Closes #325

## Review checklist
- [ ] code is readable
- [ ] tests updated/added
- [ ] edge cases handled