### PR TITLE
Fixed indoor path start and end points

### DIFF
--- a/mobile/__tests__/useProcessedSvg.test.ts
+++ b/mobile/__tests__/useProcessedSvg.test.ts
@@ -16,6 +16,15 @@ jest.mock('../src/utils/svgUtils', () => ({
     }),
 }));
 
+// Mock Pathfinding module
+jest.mock('../src/utils/Pathfinding', () => ({
+    getFloorFromNodeId: jest.fn((nodeId: string) => {
+        // Extract floor from node ID like "Hall_F8_room_291" -> 8
+        const match = nodeId.match(/_F(\d+)_/);
+        return match ? parseInt(match[1], 10) : null;
+    }),
+}));
+
 describe('useProcessedSvg', () => {
     const mockSvgContent = '<svg><rect/></svg>';
 
@@ -78,8 +87,8 @@ describe('useProcessedSvg', () => {
         it('transforms coordinates for buildings that require scaling (Hall, VE, CC)', () => {
             const path: NavMeshNode[] = [
                 // Set buildingId to 'Hall' to trigger the transformNavMeshCoordinates branch
-                { id: 'start', data: { x: 100, y: 200, buildingId: 'Hall' } as any },
-                { id: 'end', data: { x: 300, y: 400, buildingId: 'Hall' } as any },
+                { id: 'start', data: { x: 100, y: 200, buildingId: 'Hall' } },
+                { id: 'end', data: { x: 300, y: 400, buildingId: 'Hall' } },
             ];
             const pathString = 'M 50 100 L 150 200';
 
@@ -272,6 +281,117 @@ describe('useProcessedSvg', () => {
 
             // Should not log when __DEV__ is false
             expect(consoleLogSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('floor filtering', () => {
+        it('filters path nodes by floor when currentFloor is provided', () => {
+            // Multi-floor path: floor 8 -> floor 9
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20, floor: 8 } },
+                { id: 'Hall_F8_hallway_1', data: { x: 50, y: 50, floor: 8 } },
+                { id: 'Hall_F8_stair_1', data: { x: 100, y: 100, floor: 8 } },
+                { id: 'Hall_F9_stair_1', data: { x: 100, y: 100, floor: 9 } },
+                { id: 'Hall_F9_hallway_1', data: { x: 150, y: 150, floor: 9 } },
+                { id: 'Hall_F9_room_962', data: { x: 200, y: 200, floor: 9 } },
+            ];
+            const pathString = 'M 10 20 L 100 100';
+
+            // When viewing floor 8, markers should be at floor 8's start/end
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, 8)
+            );
+
+            // Should use floor 8's first and last nodes (10,20) and (100,100)
+            expect(result.current).toContain('start="10,20"');
+            expect(result.current).toContain('end="100,100"');
+        });
+
+        it('shows correct markers for floor 9 in multi-floor path', () => {
+            // Multi-floor path: floor 8 -> floor 9
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20, floor: 8 } },
+                { id: 'Hall_F8_stair_1', data: { x: 100, y: 100, floor: 8 } },
+                { id: 'Hall_F9_stair_1', data: { x: 100, y: 100, floor: 9 } },
+                { id: 'Hall_F9_room_962', data: { x: 200, y: 200, floor: 9 } },
+            ];
+            const pathString = 'M 100 100 L 200 200';
+
+            // When viewing floor 9, markers should be at floor 9's start/end
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, 9)
+            );
+
+            // Should use floor 9's first and last nodes (100,100) and (200,200)
+            expect(result.current).toContain('start="100,100"');
+            expect(result.current).toContain('end="200,200"');
+        });
+
+        it('uses all path nodes when currentFloor is undefined', () => {
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20, floor: 8 } },
+                { id: 'Hall_F9_room_962', data: { x: 200, y: 200, floor: 9 } },
+            ];
+            const pathString = 'M 10 20 L 200 200';
+
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, undefined)
+            );
+
+            // Should use entire path's first and last nodes
+            expect(result.current).toContain('start="10,20"');
+            expect(result.current).toContain('end="200,200"');
+        });
+
+        it('renders path without markers when no nodes on specified floor', () => {
+            // Path only has floor 8 nodes
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20, floor: 8 } },
+                { id: 'Hall_F8_room_862', data: { x: 100, y: 100, floor: 8 } },
+            ];
+            const pathString = 'M 10 20 L 100 100';
+
+            // When viewing floor 9 (which has no nodes)
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, 9)
+            );
+
+            // Should render path without markers (no start/end attributes)
+            expect(result.current).toContain('<path d="M 10 20 L 100 100"');
+            expect(result.current).not.toContain('start="');
+            expect(result.current).not.toContain('end="');
+        });
+
+        it('extracts floor from node ID when floor not in data', () => {
+            // Nodes without floor in data, but floor info in ID
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20 } },
+                { id: 'Hall_F8_room_862', data: { x: 100, y: 100 } },
+            ];
+            const pathString = 'M 10 20 L 100 100';
+
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, 8)
+            );
+
+            // Should extract floor from ID and include nodes
+            expect(result.current).toContain('start="10,20"');
+            expect(result.current).toContain('end="100,100"');
+        });
+
+        it('handles single node on floor', () => {
+            const path: NavMeshNode[] = [
+                { id: 'Hall_F8_room_829', data: { x: 10, y: 20, floor: 8 } },
+            ];
+            const pathString = 'M 10 20';
+
+            const { result } = renderHook(() =>
+                useProcessedSvg(mockSvgContent, path, pathString, undefined, undefined, 8)
+            );
+
+            // Single node: start and end should be the same
+            expect(result.current).toContain('start="10,20"');
+            expect(result.current).toContain('end="10,20"');
         });
     });
 

--- a/mobile/src/components/FloorPlanViewer.tsx
+++ b/mobile/src/components/FloorPlanViewer.tsx
@@ -469,7 +469,8 @@ export default function FloorPlanViewer({
         activePath,
         pathString,
         isNavigating ? undefined : startRoom,
-        isNavigating ? undefined : nextRoom
+        isNavigating ? undefined : nextRoom,
+        displayFloorNum
     );
     
     // Check if this is a multi-floor path

--- a/mobile/src/hooks/useProcessedSvg.ts
+++ b/mobile/src/hooks/useProcessedSvg.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { highlightRoomInSvg, generatePathElements } from '../utils/svgUtils';
 import { NavMeshNode } from '../types/building';
+import { getFloorFromNodeId } from '../utils/Pathfinding';
 
 // Coordinate transformation for buildings with 2x scale navmesh
 // Hall, VE, and CC buildings all use navmesh at 2x scale compared to SVG
@@ -10,12 +11,51 @@ function transformNavMeshCoordinates(x: number, y: number): { x: number; y: numb
   return { x: x * scale, y: y * scale };
 }
 
+function getFloorFromNode(node: NavMeshNode): number | null {
+  const nodeData = node.data as { floor?: number } | undefined;
+  if (nodeData?.floor !== undefined) {
+    return nodeData.floor;
+  }
+  return getFloorFromNodeId(String(node.id));
+}
+
+function filterNodesByFloor(path: NavMeshNode[], targetFloor: number): NavMeshNode[] {
+  return path.filter(node => {
+    const nodeFloor = getFloorFromNode(node);
+    return nodeFloor === targetFloor;
+  });
+}
+
+function transformBuildingCoordinates(
+  x: number, 
+  y: number, 
+  buildingId: string | undefined
+): { x: number; y: number } {
+  if (buildingId === 'Hall' || buildingId === 'VE' || buildingId === 'CC') {
+    return transformNavMeshCoordinates(x, y);
+  }
+  return { x, y };
+}
+
+function insertIntoSvg(svg: string, elements: string): string {
+  const lastSvgCloseIndex = svg.lastIndexOf('</svg>');
+  if (lastSvgCloseIndex !== -1) {
+    return svg.slice(0, lastSvgCloseIndex) + elements + svg.slice(lastSvgCloseIndex);
+  }
+  return svg + elements;
+}
+
+function createPathOnlyElement(pathString: string): string {
+  return `<path d="${pathString}" stroke="#007AFF" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>`;
+}
+
 export function useProcessedSvg(
   rawSvgContent: string | undefined,
   path: NavMeshNode[] | null,
   pathString: string,
   startRoom: string | undefined,
-  nextRoom: string | undefined
+  nextRoom: string | undefined,
+  currentFloor?: number
 ): string | undefined {
   return useMemo(() => {
     if (!rawSvgContent) {
@@ -24,14 +64,20 @@ export function useProcessedSvg(
     
     const highlighted = highlightRoomInSvg(rawSvgContent, startRoom, nextRoom);
     
-    if (!path || !pathString) {
+    if (!path || !pathString || path.length === 0) {
       // istanbul ignore next - __DEV__ is removed in production builds
       if (__DEV__) console.log('[useProcessedSvg] No path or pathString', { path: path?.length, pathString });
       return highlighted;
     }
 
-    const startNode = path[0];
-    const endNode = path.at(-1);
+    const floorNodes = currentFloor === undefined ? path : filterNodesByFloor(path, currentFloor);
+    
+    if (floorNodes.length === 0) {
+      return insertIntoSvg(highlighted, createPathOnlyElement(pathString));
+    }
+
+    const startNode = floorNodes[0];
+    const endNode = floorNodes.at(-1);
 
     if (!startNode?.data || !endNode?.data) {
       // istanbul ignore next - __DEV__ is removed in production builds
@@ -41,20 +87,13 @@ export function useProcessedSvg(
 
     // Transform coordinates based on building
     const buildingId = (startNode.data as { buildingId?: string }).buildingId;
-    
-    const transformCoord = (x: number, y: number, building: string | undefined): { x: number; y: number } => {
-      if (building === 'Hall' || building === 'VE' || building === 'CC') {
-        return transformNavMeshCoordinates(x, y);
-      }
-      // For VL and others - use coordinates directly
-      return { x, y };
-    };
-    
-    const startCoord = transformCoord(startNode.data.x, startNode.data.y, buildingId);
-    const endCoord = transformCoord(endNode.data.x, endNode.data.y, buildingId);
+    const startCoord = transformBuildingCoordinates(startNode.data.x, startNode.data.y, buildingId);
+    const endCoord = transformBuildingCoordinates(endNode.data.x, endNode.data.y, buildingId);
 
     // istanbul ignore next - __DEV__ is removed in production builds
     if (__DEV__) console.log('[useProcessedSvg] Path coordinates:', {
+      floor: currentFloor,
+      floorNodesCount: floorNodes.length,
       startX: startCoord.x,
       startY: startCoord.y,
       endX: endCoord.x,
@@ -74,13 +113,6 @@ export function useProcessedSvg(
     // istanbul ignore next - __DEV__ is removed in production builds
     if (__DEV__) console.log('[useProcessedSvg] Generated pathElements:', pathElements.substring(0, 200) + '...');
 
-    // Find the LAST </svg> tag to insert before (handles nested SVGs like icons)
-    const lastSvgCloseIndex = highlighted.lastIndexOf('</svg>');
-    if (lastSvgCloseIndex !== -1) {
-      return highlighted.slice(0, lastSvgCloseIndex) + pathElements + highlighted.slice(lastSvgCloseIndex);
-    }
-    
-    // Fallback if no </svg> tag is found (e.g. malformed SVG)
-    return highlighted + pathElements;
-  }, [rawSvgContent, path, pathString, startRoom, nextRoom]);
+    return insertIntoSvg(highlighted, pathElements);
+  }, [rawSvgContent, path, pathString, startRoom, nextRoom, currentFloor]);
 }

--- a/mobile/src/types/building.ts
+++ b/mobile/src/types/building.ts
@@ -31,7 +31,15 @@ export interface POIInfo {
 
 export interface NavMeshNode {
     id: string | number;
-    data?: { x: number; y: number };
+    data?: { 
+        x: number; 
+        y: number; 
+        floor?: number;
+        type?: string;
+        buildingId?: string;
+        label?: string;
+        accessible?: boolean;
+    };
 }
 
 /**

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
## What does this PR do?
Brief summary of the change.
Previously the start and end points were only calculated when the rooms are chosen.
This caused the points to stay constant on the floor plan even when the user switches floors.
This PR recalculates the start and end points positions when the user switches floors so that the green point is at the start of the node on the selected floor and the red point is at the end.

There's also a change to the tsconfig file because I started to get static errors in VS Code when looking at test files now for some reason.

## How to test
- [x] Unit tests: npm test
- [x] Test Coverage: npm test (or npm run test:coverage)

## Linked issue
Closes #

## Review checklist
- [x] code is readable
- [x] tests updated/added
- [x] edge cases handled