### PR TITLE
Filter POIs by distance when location set

### DIFF
--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -24,7 +24,7 @@ import type { OutdoorPOI } from '../data/outdoorPOI';
 import POIInfoPanel from '../components/POIInfoPanel';
 import POIFilter from '../components/POIFilter';
 import NearestPOIBanner from '../components/NearestPOIBanner';
-import { findNearestPOI } from '../utils/distanceUtils';
+import { findNearestPOI, calculateDistance } from '../utils/distanceUtils';
 import { getPOICategoryIcon, getPOICategoryLabel, getPOICategoryColor } from '../utils/poiMarkerUtils';
 import { useAppSettings } from '../hooks/useAppSettings';
 import {
@@ -471,10 +471,25 @@ export default function MapScreen() {
   }
   // Helper function to get POIs for current campus and active filters
   const getFilteredPOIs = useCallback(() => {
-    return outdoorPOIs.filter(
+    let filtered = outdoorPOIs.filter(
       poi => poi.campus === selectedCampus && poiFilters.has(poi.category)
     );
-  }, [selectedCampus, poiFilters]);
+
+    // Apply distance filter if user location is available
+    if (userLocation && settings?.poiRangeMeters) {
+      filtered = filtered.filter(poi => {
+        const distance = calculateDistance(
+          userLocation.latitude,
+          userLocation.longitude,
+          poi.coordinates.latitude,
+          poi.coordinates.longitude
+        );
+        return distance <= settings.poiRangeMeters;
+      });
+    }
+
+    return filtered;
+  }, [selectedCampus, poiFilters, userLocation, settings]);
 
   // Helper function to get POI color based on category
   const getPOIMarkerColor = useCallback((category: OutdoorPOI['category'], isNearest: boolean = false): string => {


### PR DESCRIPTION
Add distance-based filtering to MapScreen POI list: import calculateDistance and apply an additional filter when userLocation and settings.poiRangeMeters are available, returning only POIs within the configured range. Refactor getFilteredPOIs to build a filtered array (instead of early return) and update the hook dependencies to include userLocation and settings.

## How to test
- [ ] Unit tests: npm test
- [ ] Test Coverage: npm test (or npm run test:coverage)

## Linked issue
Closes #30 

## Review checklist
- [ ] code is readable
- [ ] tests updated/added
- [ ] edge cases handled