### PR TITLE
Removed "Done" button from route instruction

### DIFF
--- a/mobile/__tests__/RouteInstructions.test.tsx
+++ b/mobile/__tests__/RouteInstructions.test.tsx
@@ -353,7 +353,7 @@ it('evaluates both true and false branches for the toggle panel and icon', () =>
       // navigationMode = 'indoor'
       // navigationInstruction = "Custom String" (truthy)
       // isLastStep = true
-      const { getByText } = render(
+      const { getByText, queryByText } = render(
         <RouteInstructions
           instructions={mockInstructions}
           start={start}
@@ -367,7 +367,8 @@ it('evaluates both true and false branches for the toggle panel and icon', () =>
       );
       expect(getByText('directions')).toBeTruthy();
       expect(getByText('Custom instruction here')).toBeTruthy();
-      expect(getByText('Done')).toBeTruthy();
+      // When isLastStep=true, there's an invisible placeholder instead of "Next" button
+      expect(queryByText('Next')).toBeNull();
     });
 
     it('evaluates the fallback branch for indoor path without custom instruction', () => {

--- a/mobile/src/components/RouteInstructions.tsx
+++ b/mobile/src/components/RouteInstructions.tsx
@@ -145,13 +145,18 @@ const RouteInstructions = ({
                                 <Text style={[styles.navCircleBtnText, isFirstStep && styles.navCircleBtnTextDisabled]}>Prev</Text>
                             </TouchableOpacity>
 
-                            <TouchableOpacity 
-                                style={[styles.navCircleBtn, styles.navCircleBtnPrimary]} 
-                                onPress={onNextStep}
-                                activeOpacity={0.7}
-                            >
-                                <Text style={styles.navCircleBtnTextPrimary}>{isLastStep ? 'Done' : 'Next'}</Text>
-                            </TouchableOpacity>
+                            {isLastStep ? (
+                                /* Invisible placeholder keeps "Prev" button from shifting right */
+                                <View style={{ width: 56, height: 56 }} />
+                            ) : (
+                                <TouchableOpacity 
+                                    style={[styles.navCircleBtn, styles.navCircleBtnPrimary]} 
+                                    onPress={onNextStep}
+                                    activeOpacity={0.7}
+                                >
+                                    <Text style={styles.navCircleBtnTextPrimary}>Next</Text>
+                                </TouchableOpacity>
+                            )}
                         </View>
                     </View>
                 </View>

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -129,7 +129,6 @@ export default function MapScreen() {
     onExit: () => {
       setShowRoutePreview(false);
       setBuildingSelectorVisible(true);
-      setInstructions([]);
     },
     onRestoreRouteInfo: (routeInfo) => setRouteInfo(routeInfo),
   });


### PR DESCRIPTION
## What does this PR do?
Brief summary of the change.
Removed the "done" button from route instruction to prevent the user from accidentally pressing done when they thought it was a "next" button. Now the user has to press the "x" button to close route instructions.
Stop clearing instructions even when the user press the "x" button - they're needed if user restarts navigation
Instructions will be cleared when user explicitly clears the route via handleClearRoute.
The user can clear instructions by changing building/room selections or just removing the selection by pressing "x".

## How to test
- [ ] Unit tests: npm test
- [ ] Test Coverage: npm test (or npm run test:coverage)

## Linked issue
Closes #

## Review checklist
- [ ] code is readable
- [ ] tests updated/added
- [ ] edge cases handled