### PR TITLE
Removed inkscape labels for non room elements

### DIFF
--- a/mobile/src/data/svgs/hall8.ts
+++ b/mobile/src/data/svgs/hall8.ts
@@ -4,7 +4,7 @@ export const hall8Svg = `
 <linearGradient id="linearGradient4705" osb:paint="solid">
 <stop id="stop4707" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
 </linearGradient>
-<filter id="filter5156" inkscape:label="Blur" style="color-interpolation-filters:sRGB;">
+<filter id="filter5156" style="color-interpolation-filters:sRGB;">
 <feGaussianBlur id="feGaussianBlur5158" result="blur" stdDeviation="20 20"/>
 </filter>
 </defs>

--- a/mobile/src/data/svgs/john1.ts
+++ b/mobile/src/data/svgs/john1.ts
@@ -1,7 +1,7 @@
 export const john1Svg = `
 <svg fill="none" height="1024" viewBox="0 0 1024 1024" width="1024" xmlns="http://www.w3.org/2000/svg">
   <defs id="defs4" />
-  <g inkscape:label="1 vec copy" id="g3906" style="display:inline">
+  <g id="g3906" style="display:inline">
     <path id="path3908" d="m 358.57143,146.85714 102.14286,734.28572 h 15.71428 l 32.14286,111.42857 H 735 v 8.57147 h 46.42857 v 9.2857 H 980.35714 V 656.30447 H 851.5586 V 112.57143 H 815 v 17.14285 H 630.71429 v -16.42857 h -25 V 97.571428 H 397.14286 v 49.285712 z" style="fill:#f7d6d6;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path id="path3910" d="M 517.85714,97.571428 V 169 h 29.28572 v 38.57143 h 72.14285 V 113.28571 H 605.71429 V 97.571428 Z" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:label="1.294" />
     <path id="path3912" d="m 619.28571,153.28571 h 35 l 17.66827,30.60234 v 52.96909 H 851.5586 V 112.57143 H 815 v 17.14285 H 630.71429 v -16.42857 h -11.42858 z" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:label="1.265" />

--- a/mobile/src/data/svgs/ve1.ts
+++ b/mobile/src/data/svgs/ve1.ts
@@ -11,7 +11,7 @@ export const ve1Svg = `
 </cc:Work>
 </rdf:RDF>
 </metadata>
-<g id="g4664" inkscape:groupmode="layer" inkscape:label="VE1 vec copy" style="display:inline">
+<g id="g4664" inkscape:groupmode="layer" style="display:inline">
 <path d="m 790.17773,42.214844 0,94.642576 -97.21289,0 0,32.04883 0,25.75781 14.64649,0 0,6.0625 33.83984,0 0,-31.82031 48.72656,0 0,1.00977 33.60157,0 0,-47.34375 6.5664,0 0,-80.357426 -6.5664,0 -33.60157,0 z" id="path4672" inkscape:connector-curvature="0" style="fill:#f7d6d6;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
 <rect height="31.819807" id="rect4102" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" width="33.840092" x="707.61188" y="168.90587"/>
 <text alignment-baseline="middle" fill="black" font-family="Arial" font-size="15" stroke-width="0" text-anchor="middle" x="724.531926" y="184.8157735"> 102 </text>

--- a/mobile/src/data/svgs/ve2.ts
+++ b/mobile/src/data/svgs/ve2.ts
@@ -11,7 +11,7 @@ export const ve2Svg = `
 </cc:Work>
 </rdf:RDF>
 </metadata>
-<g id="g4719" inkscape:groupmode="layer" inkscape:label="VE2 vec copy" style="display:inline">
+<g id="g4719" inkscape:groupmode="layer" style="display:inline">
 <path d="m 241.42773,38.285156 0,100.000004 -35.71289,0 0,45.71484 35.71289,0 0,150.71484 302.03516,0 0,-172.7539 98.99414,0 0,5.42968 48.48828,0 0,26.76954 16.66602,0 0,140.66406 54.54883,0 0,-140.66406 0,-29.29493 32.125,0 33.53515,0 0,-42.29296 2.52539,0 0,-73.57227 -36.06054,0 0,-10.714844 -552.85743,0 z" id="path4721" inkscape:connector-curvature="0" style="display:inline;fill:#f7d6d6;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
 <rect height="58.967793" id="rect4201" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" width="50.506348" x="241.42773" y="161.96094"/>
 <text alignment-baseline="middle" fill="black" font-family="Arial" font-size="15" stroke-width="0" text-anchor="middle" x="266.680904" y="191.4448365"> 201 </text>

--- a/mobile/src/data/svgs/vl1.ts
+++ b/mobile/src/data/svgs/vl1.ts
@@ -1,7 +1,7 @@
 export const vl1Svg = `
 <svg fill="none" height="1024" viewBox="0 0 1024 1024" width="1024" xmlns="http://www.w3.org/2000/svg">
   <defs id="defs4.32" />
-  <g style="display:inline" inkscape:label="VL1 vec copy" id="g4856.47" transform="translate(-31.33,-18.21)">
+  <g style="display:inline" id="g4856.47" transform="translate(-31.33,-18.21)">
     <path id="path4858.63" d="M 224.63,19.31 V 129.23 h -21.07 v 55.51 h 18.50 v 174.26 h -20.05 v 52.43 H 215.89 v 81.73 h -49.35 v 60.14 h -55.51 v 60.14 H 58.60 v 66.31 H 33.92 V 924.94 H 64.77 V 997.42 H 32.38 v 44.72 H 383.98 V 997.42 924.94 869.83 h 40.19 v 21.81 H 896.32 919.46 V 611.13 h 90.60 13.49 29.69 v -43.95 h -29.69 V 378.66 h -13.49 v -5.78 H 932.19 V 99.16 H 914.45 V 132.31 H 896.32 V 19.31 H 383.98 Z" style="fill:#f7d6d6;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect y="996.46" x="32.41" height="44.68" width="74.09" id="rect4860.79" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:label="195" />
     <rect y="973.35" x="322.60" height="67.79" width="61.74" id="rect4862.95" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:label="101-4" />

--- a/mobile/src/data/svgs/vl2.ts
+++ b/mobile/src/data/svgs/vl2.ts
@@ -1,7 +1,7 @@
 export const vl2Svg = `
 <svg fill="none" height="1024" viewBox="0 0 1024 1024" width="1024" xmlns="http://www.w3.org/2000/svg">
   <defs id="defs4.32" />
-  <g id="g5182.47" inkscape:label="VL2 vec copy" style="display:inline" transform="translate(-31.33,-18.21)">
+  <g id="g5182.47" style="display:inline" transform="translate(-31.33,-18.21)">
     <path style="fill:#f7d6d6;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 224.63,19.31 V 129.23 h -21.07 v 55.51 h 18.50 v 174.26 h -20.05 v 52.43 H 215.89 v 81.73 h -49.35 v 60.14 h -55.51 v 60.14 H 58.60 v 66.31 H 33.92 V 924.94 H 64.77 V 997.42 H 32.38 v 44.72 H 383.98 V 997.42 924.94 869.83 h 40.19 v 21.81 H 896.32 919.46 V 611.13 h 90.60 13.49 29.69 v -43.95 h -29.69 V 378.66 h -13.49 v -5.78 H 932.19 V 99.16 H 914.45 V 132.31 H 896.32 V 19.31 H 383.98 Z" id="path5184.63" />
     <rect style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect5186.79" width="74.09" height="44.68" x="32.41" y="996.46" inkscape:label="295" />
     <path id="path5188.94" d="m 825.40,781.91 v 30.67 h 30.58 v 79.06 h 63.49 v -100.32 H 855.98 v -9.41 z" style="fill:#da3636;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" inkscape:label="240" />


### PR DESCRIPTION
## What does this PR do?
Brief summary of the change.
There were some svg elements that were recognized as rooms even though they are not rooms.
The PR fixes this by removing the inkscape labels from these elements entirely. 
Now, they wont appear as rooms in the room pickers.

The following labels are removed from the svgs:
VLVL1 vec copy
VLVL2 vec copy
VEVE1 vec copy
VEVE2 vec copy
MB1 vec copy
Hblur

<img width="432" height="951" alt="image" src="https://github.com/user-attachments/assets/7afbc2e3-8945-4965-b559-9e170eed5d91" />

## How to test
- [x] Unit tests: npm test
- [x] Test Coverage: npm test (or npm run test:coverage)

## Linked issue
Closes #385 

## Review checklist
- [x] code is readable
- [x] tests updated/added
- [x] edge cases handled